### PR TITLE
v0.7.1. Handle/return :record_too_small when inserting a record with a size less than keypos.

### DIFF
--- a/.iex.exs
+++ b/.iex.exs
@@ -1,0 +1,2 @@
+alias Ets.Set
+alias Ets.Bag

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+
+## 0.7.1
+
+* Handle and return :record_too_small when size of inserted record is smaller than keypos
+
 ## 0.7.0
 
 * Add `Access` protocol for `KeyValueSet` - Thanks @am-kantox

--- a/lib/ets/base.ex
+++ b/lib/ets/base.ex
@@ -93,9 +93,11 @@ defmodule Ets.Base do
   @spec insert(Ets.table_identifier(), tuple(), any()) :: {:ok, any()} | {:error, any()}
   def insert(table, record, return) do
     catch_error do
-      catch_table_not_found table do
-        :ets.insert(table, record)
-        {:ok, return}
+      catch_record_too_small table, record do
+        catch_table_not_found table do
+          :ets.insert(table, record)
+          {:ok, return}
+        end
       end
     end
   end
@@ -104,9 +106,11 @@ defmodule Ets.Base do
   @spec insert_new(Ets.table_identifier(), tuple(), any()) :: {:ok, any()} | {:error, any()}
   def insert_new(table, record, return) do
     catch_error do
-      catch_table_not_found table do
-        :ets.insert_new(table, record)
-        {:ok, return}
+      catch_record_too_small table, record do
+        catch_table_not_found table do
+          :ets.insert_new(table, record)
+          {:ok, return}
+        end
       end
     end
   end
@@ -116,10 +120,12 @@ defmodule Ets.Base do
           {:ok, any()} | {:error, any()}
   def insert_multi(table, records, return) do
     catch_error do
-      catch_bad_records records do
-        catch_table_not_found table do
-          :ets.insert(table, records)
-          {:ok, return}
+      catch_records_too_small table, records do
+        catch_bad_records records do
+          catch_table_not_found table do
+            :ets.insert(table, records)
+            {:ok, return}
+          end
         end
       end
     end
@@ -130,10 +136,12 @@ defmodule Ets.Base do
           {:ok, any()} | {:error, any()}
   def insert_multi_new(table, records, return) do
     catch_error do
-      catch_bad_records records do
-        catch_table_not_found table do
-          :ets.insert_new(table, records)
-          {:ok, return}
+      catch_records_too_small table, records do
+        catch_bad_records records do
+          catch_table_not_found table do
+            :ets.insert_new(table, records)
+            {:ok, return}
+          end
         end
       end
     end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Ets.MixProject do
   def project do
     [
       app: :ets,
-      version: "0.7.0",
+      version: "0.7.1",
       elixir: "~> 1.7",
       start_permanent: Mix.env() == :prod,
       deps: deps(),

--- a/test/ets/bag_test.exs
+++ b/test/ets/bag_test.exs
@@ -140,6 +140,16 @@ defmodule BagTest do
       assert_raise RuntimeError, "Ets.Bag.add!/2 returned {:error, :table_not_found}", fn ->
         Bag.add!(bag, {:a})
       end
+
+      bag2 = Bag.new!(keypos: 3)
+
+      assert_raise RuntimeError, "Ets.Bag.add!/2 returned {:error, :record_too_small}", fn ->
+        Bag.add!(bag2, {:a, :b})
+      end
+
+      assert_raise RuntimeError, "Ets.Bag.add!/2 returned {:error, :record_too_small}", fn ->
+        Bag.add!(bag2, [{:a, :b}, {:c}])
+      end
     end
 
     test "add_new!/2 raises on error" do
@@ -156,6 +166,16 @@ defmodule BagTest do
                    fn ->
                      Bag.add_new!(bag, {:a})
                    end
+
+      bag2 = Bag.new!(keypos: 3)
+
+      assert_raise RuntimeError, "Ets.Bag.add_new!/2 returned {:error, :record_too_small}", fn ->
+        Bag.add_new!(bag2, {:a, :b})
+      end
+
+      assert_raise RuntimeError, "Ets.Bag.add_new!/2 returned {:error, :record_too_small}", fn ->
+        Bag.add_new!(bag2, [{:a, :b}, {:c}])
+      end
     end
   end
 

--- a/test/ets/set_test.exs
+++ b/test/ets/set_test.exs
@@ -208,6 +208,16 @@ defmodule SetTest do
       assert_raise RuntimeError, "Ets.Set.put!/2 returned {:error, :table_not_found}", fn ->
         Set.put!(set, {:a})
       end
+
+      set2 = Set.new!(keypos: 3)
+
+      assert_raise RuntimeError, "Ets.Set.put!/2 returned {:error, :record_too_small}", fn ->
+        Set.put!(set2, {:a, :b})
+      end
+
+      assert_raise RuntimeError, "Ets.Set.put!/2 returned {:error, :record_too_small}", fn ->
+        Set.put!(set2, [{:a, :b}, {:c}])
+      end
     end
   end
 
@@ -249,6 +259,16 @@ defmodule SetTest do
                    fn ->
                      Set.put_new!(set, {:a})
                    end
+
+      set2 = Set.new!(keypos: 3)
+
+      assert_raise RuntimeError, "Ets.Set.put_new!/2 returned {:error, :record_too_small}", fn ->
+        Set.put_new!(set2, {:a, :b})
+      end
+
+      assert_raise RuntimeError, "Ets.Set.put_new!/2 returned {:error, :record_too_small}", fn ->
+        Set.put_new!(set2, [{:a, :b}, {:c}])
+      end
     end
   end
 


### PR DESCRIPTION
Added checks on arg-error on all variations of insert that checks to see if the error was caused by a record that is smaller than the configured keypos.