### PR TITLE
Handle and return :position_out_of_bounds error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Next
+
+* Handle and return :position_out_of_bounds when calling `get_element`/`lookup_element` with a position greater than the size of one of the returned tuples
+
 ## 0.7.3
 
 * Handle and return :read_protected error when reading from a private table from a different process

--- a/lib/ets/base.ex
+++ b/lib/ets/base.ex
@@ -183,11 +183,13 @@ defmodule Ets.Base do
           {:ok, any()} | {:error, any()}
   def lookup_element(table, key, pos) do
     catch_error do
-      catch_read_protected table do
+      catch_position_out_of_bounds table, key, pos do
         catch_key_not_found table, key do
-          catch_table_not_found table do
-            vals = :ets.lookup_element(table, key, pos)
-            {:ok, vals}
+          catch_read_protected table do
+            catch_table_not_found table do
+              vals = :ets.lookup_element(table, key, pos)
+              {:ok, vals}
+            end
           end
         end
       end

--- a/lib/ets/utils.ex
+++ b/lib/ets/utils.ex
@@ -125,6 +125,24 @@ defmodule Ets.Utils do
     end
   end
 
+  defmacro catch_position_out_of_bounds(table, key, pos, do: do_block) do
+    quote do
+      try do
+        unquote(do_block)
+      rescue
+        e in ArgumentError ->
+          unquote(table)
+          |> :ets.lookup(unquote(key))
+          |> Enum.any?(&(tuple_size(&1) < unquote(pos)))
+          |> if do
+            {:error, :position_out_of_bounds}
+          else
+            reraise(e, __STACKTRACE__)
+          end
+      end
+    end
+  end
+
   defmacro catch_invalid_select_spec(spec, do: do_block) do
     quote do
       try do

--- a/test/ets/bag_test.exs
+++ b/test/ets/bag_test.exs
@@ -189,6 +189,17 @@ defmodule BagTest do
                      Bag.lookup_element!(bag, :not_a_key, 2)
                    end
 
+      Bag.add!(bag, {:a, :b, :c, :d, :e})
+      Bag.add!(bag, {:a, :e, :f, :g})
+
+      assert_raise RuntimeError,
+                   "Ets.Bag.lookup_element!/3 returned {:error, :position_out_of_bounds}",
+                   fn -> Bag.lookup_element!(bag, :a, 5) end
+
+      assert_raise RuntimeError,
+                   "Ets.Bag.lookup_element!/3 returned {:error, :position_out_of_bounds}",
+                   fn -> Bag.lookup_element!(bag, :a, 6) end
+
       Bag.delete!(bag)
 
       assert_raise RuntimeError,

--- a/test/ets/set_test.exs
+++ b/test/ets/set_test.exs
@@ -388,6 +388,12 @@ defmodule SetTest do
         Set.get_element!(set, :not_a_key, 2)
       end
 
+      Set.put!(set, {:a, :b, :c, :d})
+
+      assert_raise RuntimeError,
+                   "Ets.Set.get_element!/3 returned {:error, :position_out_of_bounds}",
+                   fn -> Set.get_element!(set, :a, 5) end
+
       Set.delete!(set)
 
       assert_raise RuntimeError,


### PR DESCRIPTION
when calling `get_element`/`lookup_element` with a position greater than the size of one of the returned tuples