### PR TITLE
add select-1 and select-3

### DIFF
--- a/lib/ets.ex
+++ b/lib/ets.ex
@@ -28,11 +28,12 @@ defmodule Ets do
   @type table_identifier :: table_name | table_reference
   @type match_pattern :: :ets.match_pattern()
   @type match_spec :: :ets.match_spec()
+  @type comp_match_spec :: :ets.comp_match_spec()
   @type end_of_table :: :"$end_of_table"
   @type continuation ::
           end_of_table
-          | {:ets.table(), integer(), integer(), :ets.comp_match_spec(), list(), integer()}
-          | {:ets.table(), any(), any(), integer(), :ets.comp_match_spec(), list(), integer(),
+          | {table_reference(), integer(), integer(), comp_match_spec(), list(), integer()}
+          | {table_reference(), any(), any(), integer(), comp_match_spec(), list(), integer(),
              integer()}
 
   @doc """

--- a/lib/ets.ex
+++ b/lib/ets.ex
@@ -28,6 +28,8 @@ defmodule Ets do
   @type table_identifier :: table_name | table_reference
   @type match_pattern :: :ets.match_pattern()
   @type match_spec :: :ets.match_spec()
+  @type continuation :: :ets.continuation()
+  @type end_of_table :: :"$end_of_table"
 
   @doc """
   Returns list of current :ets tables, each wrapped as either `Ets.Set` or `Ets.Bag`.

--- a/lib/ets.ex
+++ b/lib/ets.ex
@@ -28,10 +28,12 @@ defmodule Ets do
   @type table_identifier :: table_name | table_reference
   @type match_pattern :: :ets.match_pattern()
   @type match_spec :: :ets.match_spec()
-  @type continuation :: end_of_table |
-       {:ets.table(), integer(), integer(), :ets.comp_match_spec(), list(), integer()} |
-       {:ets.table, any(), any(), integer(), :ets.comp_match_spec(), list(), integer(),  integer()}
   @type end_of_table :: :"$end_of_table"
+  @type continuation ::
+          end_of_table
+          | {:ets.table(), integer(), integer(), :ets.comp_match_spec(), list(), integer()}
+          | {:ets.table(), any(), any(), integer(), :ets.comp_match_spec(), list(), integer(),
+             integer()}
 
   @doc """
   Returns list of current :ets tables, each wrapped as either `Ets.Set` or `Ets.Bag`.

--- a/lib/ets.ex
+++ b/lib/ets.ex
@@ -28,7 +28,9 @@ defmodule Ets do
   @type table_identifier :: table_name | table_reference
   @type match_pattern :: :ets.match_pattern()
   @type match_spec :: :ets.match_spec()
-  @type continuation :: :ets.continuation()
+  @type continuation :: end_of_table |
+       {:ets.table(), integer(), integer(), :ets.comp_match_spec(), list(), integer()} |
+       {:ets.table, any(), any(), integer(), :ets.comp_match_spec(), list(), integer(),  integer()}
   @type end_of_table :: :"$end_of_table"
 
   @doc """

--- a/lib/ets/base.ex
+++ b/lib/ets/base.ex
@@ -243,6 +243,17 @@ defmodule Ets.Base do
     end
   end
 
+  @spec select(Ets.continuation()) ::
+          {:ok, {[tuple()], Ets.continuation()} | Ets.end_of_table()} | {:error, any()}
+  def select(continuation) do
+    catch_error do
+      catch_invalid_continuation continuation do
+        matches = :ets.select(continuation)
+        {:ok, matches}
+      end
+    end
+  end
+
   @doc false
   @spec select(Ets.table_identifier(), Ets.match_spec()) :: {:ok, [tuple()]} | {:error, any()}
   def select(table, spec) when is_list(spec) do
@@ -251,6 +262,22 @@ defmodule Ets.Base do
         catch_invalid_select_spec spec do
           catch_table_not_found table do
             matches = :ets.select(table, spec)
+            {:ok, matches}
+          end
+        end
+      end
+    end
+  end
+
+  @doc false
+  @spec select(Ets.table_identifier(), Ets.match_spec(), limit :: integer) ::
+          {:ok, {[tuple()], Ets.continuation()} | Ets.end_of_table()} | {:error, any()}
+  def select(table, spec, limit) when is_list(spec) do
+    catch_error do
+      catch_read_protected table do
+        catch_invalid_select_spec spec do
+          catch_table_not_found table do
+            matches = :ets.select(table, spec, limit)
             {:ok, matches}
           end
         end

--- a/lib/ets/set.ex
+++ b/lib/ets/set.ex
@@ -421,7 +421,8 @@ defmodule Ets.Set do
   @doc """
   Same as `select/3` but unwraps or raises on error.
   """
-  @spec select!(Set.t(), Ets.match_spec(), limit :: integer) :: [tuple()]
+  @spec select!(Set.t(), Ets.match_spec(), limit :: integer) ::
+          {[tuple()], Ets.continuation()} | Ets.end_of_table()
   def select!(%Set{} = set, spec, limit) when is_list(spec),
     do: unwrap_or_raise(select(set, spec, limit))
 

--- a/lib/ets/set.ex
+++ b/lib/ets/set.ex
@@ -382,6 +382,10 @@ defmodule Ets.Set do
   @spec match!(any()) :: {[tuple()], any() | :end_of_table}
   def match!(continuation), do: unwrap_or_raise(match(continuation))
 
+  @spec select(Ets.continuation()) ::
+          {:ok, {[tuple()], Ets.continuation()} | Ets.end_of_table()} | {:error, any()}
+  def select(continuation), do: Base.select(continuation)
+
   @doc """
   Returns records in the specified Set that match the specified match specification.
 
@@ -400,11 +404,26 @@ defmodule Ets.Set do
     do: Base.select(table, spec)
 
   @doc """
+  Same as `select/2` but limits the number of results returned.
+  """
+  @spec select(Set.t(), Ets.match_spec(), limit :: integer) ::
+          {:ok, {[tuple()], Ets.continuation()} | Ets.end_of_table()} | {:error, any()}
+  def select(%Set{table: table}, spec, limit) when is_list(spec),
+    do: Base.select(table, spec, limit)
+
+  @doc """
   Same as `select/2` but unwraps or raises on error.
   """
   @spec select!(Set.t(), Ets.match_spec()) :: [tuple()]
   def select!(%Set{} = set, spec) when is_list(spec),
     do: unwrap_or_raise(select(set, spec))
+
+  @doc """
+  Same as `select/3` but unwraps or raises on error.
+  """
+  @spec select!(Set.t(), Ets.match_spec(), limit :: integer) :: [tuple()]
+  def select!(%Set{} = set, spec, limit) when is_list(spec),
+    do: unwrap_or_raise(select(set, spec, limit))
 
   @doc """
   Deletes records in the specified Set that match the specified match specification.

--- a/lib/ets/set.ex
+++ b/lib/ets/set.ex
@@ -386,6 +386,11 @@ defmodule Ets.Set do
           {:ok, {[tuple()], Ets.continuation()} | Ets.end_of_table()} | {:error, any()}
   def select(continuation), do: Base.select(continuation)
 
+  @spec select!(Ets.continuation()) :: {[tuple()], Ets.continuation()} | Ets.end_of_table()
+  def select!(continuation) do
+    unwrap_or_raise(select(continuation))
+  end
+
   @doc """
   Returns records in the specified Set that match the specified match specification.
 
@@ -404,19 +409,19 @@ defmodule Ets.Set do
     do: Base.select(table, spec)
 
   @doc """
+  Same as `select/2` but unwraps or raises on error.
+  """
+  @spec select!(Set.t(), Ets.match_spec()) :: [tuple()]
+  def select!(%Set{} = set, spec) when is_list(spec),
+    do: unwrap_or_raise(select(set, spec))
+
+  @doc """
   Same as `select/2` but limits the number of results returned.
   """
   @spec select(Set.t(), Ets.match_spec(), limit :: integer) ::
           {:ok, {[tuple()], Ets.continuation()} | Ets.end_of_table()} | {:error, any()}
   def select(%Set{table: table}, spec, limit) when is_list(spec),
     do: Base.select(table, spec, limit)
-
-  @doc """
-  Same as `select/2` but unwraps or raises on error.
-  """
-  @spec select!(Set.t(), Ets.match_spec()) :: [tuple()]
-  def select!(%Set{} = set, spec) when is_list(spec),
-    do: unwrap_or_raise(select(set, spec))
 
   @doc """
   Same as `select/3` but unwraps or raises on error.

--- a/test/ets/set_test.exs
+++ b/test/ets/set_test.exs
@@ -450,6 +450,41 @@ defmodule SetTest do
                      Set.select_delete!(set, [])
                    end
     end
+
+    test "select!/3 raises on error" do
+      set = Set.new!()
+      Set.delete(set)
+
+      assert_raise RuntimeError, "Ets.Set.select!/3 returned {:error, :table_not_found}", fn ->
+        Set.select!(set, [{[:"$"], [], [:"$_"]}], 10)
+      end
+    end
+
+    test "select!/1 raises on error" do
+      set = Set.new!()
+      Set.put!(set, {1, "one"})
+      Set.put!(set, {2, "two"})
+
+      {_, continuation} = Set.select!(set, [{:_, [], [:"$_"]}], 1)
+
+      Set.delete(set)
+
+      assert_raise RuntimeError, "Ets.Set.select!/1 returned {:error, :table_not_found}", fn ->
+        Set.select!(continuation)
+      end
+    end
+
+    test "select!/3 continuation can be used with select!/1" do
+      set = Set.new!()
+      Set.put!(set, {1, "one"})
+      Set.put!(set, {2, "two"})
+
+      {[{2, "two"}], continuation} = Set.select!(set, [{:_, [], [:"$_"]}], 1)
+
+      assert {[{1, "one"}], continuation} = Set.select!(continuation)
+
+      assert :"$end_of_table" = Set.select!(continuation)
+    end
   end
 
   describe "Has Key" do


### PR DESCRIPTION
I needed `select/3` and `select/1` so I figured I'd contribute them back to the library. The type for a `continuation` is opaque, so we may not want to even try to validate it here because its meant to be private, but given its structure there are a lot of errors that could be hard to catch, then, because if we don't open up the continuation we won't know what table is trying to be accessed, that kind of thing. Anyway, let me know what you think :) 