### PR TITLE
Fix 404 doc link and connect it to master

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -10,7 +10,11 @@ defmodule ETS.MixProject do
       deps: deps(),
       description: description(),
       elixirc_paths: elixirc_paths(Mix.env()),
-      docs: [main: "ETS", extras: ["README.md"]],
+      docs: [
+        main: "ETS",
+        extras: ["README.md"],
+        source_ref: "master"
+      ],
       package: package(),
       source_url: "https://github.com/TheFirstAvenger/ets",
       test_coverage: [tool: ExCoveralls],


### PR DESCRIPTION
When in `hexdocs` we click to see the code of a function it sends us to a 404 GitHub page because it is linking to main instead of master branch.